### PR TITLE
Add Printer module

### DIFF
--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -1,0 +1,44 @@
+open Core_kernel
+open Format
+
+open Term
+
+let delimiters_of_string = function
+  | "round" -> "(", ")"
+  | "square" -> "[", "]"
+  | "angle" -> "<", ">"
+  | "curly" -> "{", "}"
+  | "block" -> "", ""
+  | s -> failwith @@ sprintf "Unsupported delimiter %s" s
+
+
+let enclose_with (left,right) s =
+  left ^ s ^ right
+
+
+let rec pp formatter term =
+  match term with
+  | Const c -> Format.fprintf formatter "%s" c
+  | Var (v,_) -> Format.fprintf formatter ":[%s]" v
+  | Compound (delimiter, terms) ->
+    let left,right = delimiters_of_string delimiter in
+    Format.fprintf formatter "%s%a%s" left pp_list terms right
+and pp_list formatter term_list =
+  match term_list with
+  | [] -> Format.fprintf formatter ""
+  | [term] -> Format.fprintf formatter "%a" pp term
+  | term::terms -> Format.fprintf formatter "%a%a" pp term pp_list terms
+
+
+let to_string term =
+  Format.asprintf "%a" pp term
+
+
+let pps () term =
+  to_string term
+
+
+let ppo out term : unit =
+  let formatter = Format.formatter_of_out_channel out in
+  pp formatter term;
+  Format.pp_print_flush formatter ()

--- a/lib/printer.mli
+++ b/lib/printer.mli
@@ -1,0 +1,10 @@
+open Core_kernel
+open Format
+
+val to_string : Term.t -> string
+
+val pp : formatter -> Term.t -> unit
+
+val pps : unit -> Term.t -> string
+
+val ppo : Out_channel.t -> Term.t -> unit

--- a/test/test_rooibos.ml
+++ b/test/test_rooibos.ml
@@ -102,11 +102,42 @@ let test_unify _ =
     ([!"a,b,c"; !":"])
     ([Environment.lookup env ("1",0); Environment.lookup env ("2",0)])
 
+let test_printer _ =
+  let term = !"x()" in
+  assert_equal
+    ("x()")
+    (Printer.to_string term);
+
+  let term = !":[1]" in
+  assert_equal
+    (":[1]")
+    (Printer.to_string term);
+
+  let env =
+    let env = Environment.create () in
+    Environment.add env ("1",0) (Term.Const ":)") in
+  let term =
+    !":[1]"
+    |> Environment.substitute env in
+  assert_equal
+    (":)")
+    (Printer.to_string term);
+
+  let env =
+    let env = Environment.create () in
+    Environment.add env ("1",0) (Term.Const "dst") in
+  let term =
+    !"strcpy(:[1],src)"
+    |> Environment.substitute env in
+  assert_equal
+    ("strcpy(dst,src)")
+    (Printer.to_string term)
 
   let suite =
     "test" >::: [
       "test_parser" >:: test_parser
     ; "test_unify" >:: test_unify
+    ; "test_printer" >:: test_printer
     ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Various printing functions (to file, to string, formatted printing) for rewriter output. `Printer` is intended to be the module that outputs the final syntax. It should not do, e.g., substitution, this will be the job of e.g., `Rewriter`. We might usefully will keep `Term.to_string` as "internal" `to_string` representations for debugging. #9 