### PR TITLE
Pointer separator

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -15,14 +15,6 @@ let to_term s =
 
 let () =
   match Array.to_list Sys.argv with
-  | _ :: "-i" :: template :: source :: rewrite_template :: _ ->
-    begin match Match.find (to_term template) (to_term source) with
-      | Some (env,_) ->
-        (* Format.printf "Match: %s@." (Environment.to_string env); *)
-        let rewritten = Environment.substitute env (to_term rewrite_template) in
-        Format.printf "%s" (Printer.to_string rewritten)
-      | None -> failwith "No match"
-    end
   | _ :: template :: source :: rewrite_template :: _ ->
     let template = In_channel.read_all template in
     let source = In_channel.read_all source in


### PR DESCRIPTION
Think it's quite sensible to have `->` be a pointer so that we can match on `foo->bar` with 
`:[1]->:[2]` (doesn't work otherwise). Shall think about ways to introduce these types of rules flexibly.